### PR TITLE
Add fishing catch drop table tool

### DIFF
--- a/ModdersToolkit.cs
+++ b/ModdersToolkit.cs
@@ -46,6 +46,7 @@ namespace ModdersToolkit
 			AddTool(new Tools.PlayerLayer.PlayerLayerTool());
 			AddTool(new Tools.InterfaceLayer.InterfaceLayerTool());
 			AddTool(new Tools.Spawns.SpawnTool());
+			AddTool(new Tools.Fishing.FishingTool());
 			AddTool(new Tools.Textures.TextureTool());
 			if (Platform.IsWindows)
 				tools.Add(new Tools.Shaders.ShaderTool());

--- a/Tools/Fishing/FishingCatchesProjectile.cs
+++ b/Tools/Fishing/FishingCatchesProjectile.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using Terraria;
+using Terraria.ModLoader;
+
+namespace ModdersToolkit.Tools.Fishing
+{
+	// This class is used in conjunction with the FishingTool to "trigger" a catch the first tick the bobber gets wet
+	// It then gets logged, and will repeat every call of AI until the testing is complete
+	internal class FishingCatchesProjectile : GlobalProjectile
+	{
+		public override void AI(Projectile projectile) {
+			if (!FishingTool.currentlyTesting) {
+				return;
+			}
+			if (!projectile.bobber) {
+				return;
+			}
+			if (!projectile.wet) {
+				return;
+			}
+
+			Player player = Main.player[projectile.owner];
+
+			//Simulate pre-FishingCheck preparation code:
+			projectile.ai[0] = 0f; // Catchable state
+			projectile.localAI[1] = 0f; // Catch timer reached
+
+			if (Main.myPlayer == projectile.owner) {
+				projectile.FishingCheck(); // Calls ModPlayer.CatchFish, after that assigns localAI[1] to the catch type
+			}
+
+			// Player.ItemCheck then checks if ai[0] is 0, and localAI[1] is above 0, then sets ai[0] to 1f and ai[1] to be localAI[1]
+			// Simulate Player.ItemCheck here:
+			if (projectile.ai[0] == 0 && projectile.localAI[1] > 0) {
+				projectile.ai[0] = 1f;
+				projectile.ai[1] = projectile.localAI[1];
+			}
+
+			// Prematurely reset it here:
+			if (projectile.ai[1] > 0f && projectile.localAI[1] >= 0f) {
+				projectile.localAI[1] = -1;
+				// ...
+			}
+
+			// Projectile.AI then checks if ai[0] >= 1f and will reel in the bobber
+			// Once it collides with the player, it will spawn the item assigned to ai[1]
+
+			// The collision is prevented to not spawn the items on the player during testing by 
+			// 1. only calling AI (and not Update, which calls HandleMovement)
+			// 2. moving the player hitbox out of the way before starting the testing
+
+			int itemType = (int)projectile.ai[1];
+
+			Dictionary<int, int> catches = FishingTool.catches;
+			catches.TryGetValue(itemType, out int currentCount);
+			catches[itemType] = currentCount + 1;
+		}
+	}
+}

--- a/Tools/Fishing/FishingTool.cs
+++ b/Tools/Fishing/FishingTool.cs
@@ -1,0 +1,271 @@
+﻿using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+using Terraria;
+using Terraria.ID;
+using Terraria.UI;
+
+namespace ModdersToolkit.Tools.Fishing
+{
+	// code based on SpawnTool
+	internal class FishingTool : Tool
+	{
+		internal const int Tries = 1000;
+		internal static bool currentlyTesting = false;
+		internal static Dictionary<int, int> catches; // keys below 1 are treated as "no catch", special check in UI
+
+		internal static FishingUI fishingUI;
+
+		public override void Initialize() {
+			ToggleTooltip = "Click to toggle Fishing Tool";
+			catches = new Dictionary<int, int>();
+		}
+
+		public override void ClientInitialize() {
+			Interface = new UserInterface();
+
+			fishingUI = new FishingUI(Interface);
+			fishingUI.Activate();
+
+			Interface.SetState(fishingUI);
+		}
+
+		public override void ClientTerminate() {
+			Interface = null;
+
+			fishingUI.Deactivate();
+			fishingUI = null;
+
+			currentlyTesting = false; // Just in case
+			catches = null;
+		}
+
+		public override void UIDraw() {
+			if (Visible) {
+				fishingUI.Draw(Main.spriteBatch);
+			}
+		}
+
+		internal static int GetPoolStats(Vector2 startPosition, out bool lava, out bool honey) {
+			// Vanilla code to determine pool size of a liquid lake
+			// Added GetTileSafely just in case, and a visualizer
+
+			// This only works if the start position is already in liquid
+			int startX = (int)(startPosition.X / 16f);
+			int startY = (int)(startPosition.Y / 16f);
+			if (Main.tile[startX, startY].liquid < 0) {
+				// ???
+				startY++;
+			}
+
+			lava = false;
+			honey = false;
+			int leftStart = startX;
+			int rightEnd = startX;
+			while (leftStart > 10 && Framing.GetTileSafely(leftStart, startY).liquid > 0 && !WorldGen.SolidTile(leftStart, startY)) {
+				leftStart--;
+			}
+
+			for (; rightEnd < Main.maxTilesX - 10 && Framing.GetTileSafely(rightEnd, startY).liquid > 0 && !WorldGen.SolidTile(rightEnd, startY); rightEnd++) {
+			}
+
+			int poolSize = 0;
+			for (int x = leftStart; x <= rightEnd; x++) {
+				int y = startY;
+				while (Framing.GetTileSafely(x, y).liquid > 0 && !WorldGen.SolidTile(x, y) && y < Main.maxTilesY - 10) {
+					poolSize++;
+					y++;
+					Tile tile = Framing.GetTileSafely(x, y);
+					if (tile.lava()) {
+						lava = true;
+					}
+					else if (tile.honey()) {
+						honey = true;
+					}
+
+					// Added code to visualize pool dimensions
+					if (poolSize < 1000) {
+						// 1000 is highest value vanilla checks
+						Dust dust = Dust.NewDustPerfect(new Vector2(x, y) * 16 + new Vector2(8), 6, Vector2.Zero, Scale: 1.5f);
+						dust.noGravity = true;
+						dust.noLight = true;
+					}
+				}
+			}
+
+			if (honey) {
+				poolSize = (int)(poolSize * 1.5f);
+			}
+
+			return poolSize;
+		}
+
+		internal static bool ValidateSpawnPosition(Player player, out Vector2 spawnPosition) {
+			spawnPosition = Vector2.Zero;
+			// Find suitable spot to spawn a bobber at
+
+			//if (player.wet) {
+			//	Main.NewText("Player needs to NOT be in liquids");
+			//	return false;
+			//}
+
+			if (player.HeldItem.fishingPole <= 0) {
+				Main.NewText("Player needs to hold a fishing pole");
+				return false;
+			}
+
+			bool hasBait = false;
+			for (int j = 0; j < Main.maxInventory; j++) {
+				Item item = player.inventory[j];
+				if (!item.IsAir && item.bait > 0 && item.type != ItemID.TruffleWorm) {
+					hasBait = true;
+					break;
+				}
+			}
+
+			if (!hasBait) {
+				Main.NewText("Player needs to have bait in the inventory");
+				return false;
+			}
+
+			// Check if any liquid exists below player in a 2 wide pillar (until maxYRange)
+			// both directions: If starting tile has liquid: check downwards
+			//    If not: check upwards
+
+			int startX = (int)(player.Left.X / 16);
+			int endX = startX + 1;
+			int startY = (int)(player.Center.Y / 16);
+			int x = startX;
+			int y = startY;
+			int maxYRange = 30;
+			bool inLiquidAndAirAbove = false;
+			bool inAirAndLiquidBelow = false;
+
+			if (Framing.GetTileSafely(startX, startY).liquid > 0) {
+				//Check upwards for air
+				while (WorldGen.InWorld(x, y, 40) && y >= startY - maxYRange) {
+					for (x = startX; x <= endX; x++) {
+						Tile tile = Framing.GetTileSafely(x, y);
+						if (!tile.nactive() && tile.liquid == 0) {
+							inLiquidAndAirAbove = true;
+							break;
+						}
+
+						if (x == endX) {
+							y--;
+						}
+					}
+
+					if (inLiquidAndAirAbove) {
+						break;
+					}
+				}
+			}
+			else {
+				//Check downwards for liquid
+				while (WorldGen.InWorld(x, y, 40) && y < startY + maxYRange) {
+					for (x = startX; x <= endX; x++) {
+						Tile tile = Framing.GetTileSafely(x, y);
+						if (!tile.nactive() && tile.liquid > 0) {
+							inAirAndLiquidBelow = true;
+							y--; // -1 so above water, bobbers need to be in air for atleast one tick
+							break;
+						}
+
+						if (x == endX) {
+							y++;
+						}
+					}
+
+					if (inAirAndLiquidBelow) {
+						break;
+					}
+				}
+			}
+
+			if (!inAirAndLiquidBelow && !inLiquidAndAirAbove) {
+				string genericPositionTip = $"Tip: Stand/Hover a small distance over the pool or submerged in the pool";
+				Main.NewText($"Player needs to be within atleast {maxYRange} tiles below or above the surface of a pool of liquid");
+
+				Main.NewText(genericPositionTip);
+				return false;
+			}
+
+			spawnPosition = new Vector2(x, y) * 16;
+			return true;
+		}
+
+		internal static void CalculateCatches(Vector2 spawnPosition, int bobberType, out int poolSize, out bool lava, out bool honey) {
+			poolSize = 0;
+			lava = false;
+			honey = false;
+			// Spawn bobber with downward starting velocity
+			int index = Projectile.NewProjectile(spawnPosition, Vector2.UnitY * 8, bobberType, 0, 0f, Main.myPlayer);
+			if (index >= Main.maxProjectiles) {
+				return;
+			}
+
+			Projectile bobber = Main.projectile[index];
+
+			Player player = Main.LocalPlayer;
+			Vector2 originalCenter = player.Center;
+			bool originalWet = player.wet;
+			bool originalHoneyWet = player.honeyWet;
+			bool originalLavaWet = player.lavaWet;
+
+			// Debug: Visualize bobber spawn location
+			//for (int i = 0; i < 10; i++)
+			//{
+			//	Dust.NewDust(bobber.position, 16, 16, DustID.Fire);
+			//}
+
+			catches.Clear();
+
+			currentlyTesting = true;
+			try {
+				int failureCount = 0;
+
+				player.Center = spawnPosition - new Vector2(0f, bobber.height * 2); //Temporarily teleport player above the bobber + twice the bobbers height
+				player.wet = false;
+				player.honeyWet = false;
+				player.lavaWet = false;
+
+				for (int i = 0; i < Tries; i++) {
+					failureCount++;
+
+					if (!bobber.wet) {
+						// If not wet, call Update so it moves into liquid first (handles everything including AI)
+						bobber.Update(index);
+						i--; // Make sure we actually test Tries times, the bobber does not catch if not wet
+					}
+					else {
+						// Once wet, just call AI. Calling Update will reel the bobber back to the player otherwise, which is not intended
+						bobber.AI();
+
+						if (poolSize == 0) {
+							poolSize = GetPoolStats(bobber.Center, out lava, out honey);
+						}
+					}
+
+					if (failureCount >= 2 * Tries) {
+						break;
+					}
+				}
+			}
+			finally {
+				player.Center = originalCenter;
+				player.wet = originalWet;
+				player.honeyWet = originalHoneyWet;
+				player.lavaWet = originalLavaWet;
+				currentlyTesting = false;
+			}
+
+			bobber.Kill();
+
+			// Debug: Visualize bobber final location
+			//for (int i = 0; i < 10; i++)
+			//{
+			//	Dust.NewDust(bobber.position, 16, 16, DustID.Fire);
+			//}
+		}
+	}
+}

--- a/Tools/Fishing/FishingUI.cs
+++ b/Tools/Fishing/FishingUI.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Terraria;
+using Terraria.GameContent.UI.Elements;
+using Terraria.UI;
+
+namespace ModdersToolkit.Tools.Fishing
+{
+	// code based on SpawnUI
+	internal class FishingUI : UIToolState
+	{
+		internal UIPanel mainPanel;
+		public UIList checklistList;
+		private UserInterface userInterface;
+
+		public FishingUI(UserInterface userInterface) {
+			this.userInterface = userInterface;
+		}
+
+		public override void OnInitialize() {
+			base.OnInitialize();
+
+			mainPanel = new UIPanel();
+			mainPanel.SetPadding(6);
+			height = 350;
+			width = 200;
+			mainPanel.BackgroundColor = new Color(173, 94, 171);
+
+			UIText text = new UIText("Fishing Catches:", 0.85f);
+			//	text.Top.Set(12f, 0f);
+			//	text.Left.Set(12f, 0f);
+			mainPanel.Append(text);
+
+			int top = 20;
+
+			UITextPanel<string> calculateButton = new UITextPanel<string>("Calculate");
+			calculateButton.SetPadding(4);
+			calculateButton.Width.Set(-10, 0.5f);
+			calculateButton.Top.Set(top, 0f);
+			//	calculateButton.Left.Set(6, 0f);
+			calculateButton.OnClick += CalculateButton_OnClick;
+			mainPanel.Append(calculateButton);
+
+			top += 28;
+
+			checklistList = new UIList();
+			//	checklistList.SetPadding(6);
+			checklistList.Top.Pixels = top;
+			checklistList.Width.Set(-25f, 1f);
+			checklistList.Height.Set(-top, 1f);
+			checklistList.ListPadding = 6f;
+			mainPanel.Append(checklistList);
+
+			var checklistListScrollbar = new UIElements.FixedUIScrollbar(userInterface);
+			checklistListScrollbar.SetView(100f, 1000f);
+			//checklistListScrollbar.Height.Set(0f, 1f);
+			checklistListScrollbar.Top.Pixels = top;
+			checklistListScrollbar.Height.Set(-top, 1f);
+			checklistListScrollbar.Left.Set(-20, 1f);
+			//checklistListScrollbar.HAlign = 1f;
+			mainPanel.Append(checklistListScrollbar);
+			checklistList.SetScrollbar(checklistListScrollbar);
+
+			AdjustMainPanelDimensions(mainPanel);
+			Append(mainPanel);
+		}
+
+		private void CalculateButton_OnClick(UIMouseEvent evt, UIElement listeningElement) {
+			Player player = Main.LocalPlayer;
+			if (!FishingTool.ValidateSpawnPosition(player, out Vector2 spawnPosition)) {
+				return;
+			}
+
+			Main.NewText("Calculating....");
+
+			FishingTool.CalculateCatches(spawnPosition, player.HeldItem.shoot, out int poolSize, out bool lava, out bool honey);
+
+			checklistList.Clear();
+
+			float total = 0;
+			foreach (var catchPair in FishingTool.catches) {
+				total += catchPair.Value;
+			}
+
+			if (total > 0) {
+				foreach (var catchPair in FishingTool.catches) {
+					UIFishingCatchesInfo spawnInfo = new UIFishingCatchesInfo(catchPair.Key, catchPair.Value / total);
+					checklistList.Add(spawnInfo);
+				}
+			}
+
+			// Helpful message
+			string liquidName = "water";
+			if (lava) {
+				liquidName = "lava";
+			}
+			else if (honey) {
+				liquidName = "honey";
+			}
+
+			int fishingPower = player.FishingLevel();
+
+			Main.NewText($"Tested {total} fishing cases with {fishingPower} fishing power in a pool of {liquidName} with size {poolSize}");
+		}
+
+		protected override void DrawSelf(SpriteBatch spriteBatch) {
+			if (mainPanel.ContainsPoint(Main.MouseScreen)) {
+				Main.LocalPlayer.mouseInterface = true;
+			}
+		}
+	}
+}

--- a/Tools/Fishing/UIFishingCatchesInfo.cs
+++ b/Tools/Fishing/UIFishingCatchesInfo.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Terraria.UI;
+using Terraria;
+using Terraria.GameContent.UI.Elements;
+
+namespace ModdersToolkit.Tools.Fishing
+{
+	// code based on SpawnUI
+	internal class UIFishingCatchesInfo : UIElement
+	{
+		internal UIFishingCatchesSlot npcSlot;
+		internal UIText information;
+		internal UIText percentText;
+		internal int itemid;
+		internal float percent;
+
+		public UIFishingCatchesInfo(int itemid, float percent) {
+			this.itemid = itemid;
+			this.percent = 100 * percent;
+			Width = StyleDimension.Fill;
+			Height.Pixels = 32;
+
+			Item item = new Item();
+			item.SetDefaults(itemid);
+
+			npcSlot = new UIFishingCatchesSlot(item);
+			Append(npcSlot);
+
+			string name;
+			if (itemid <= 0) {
+				name = "Nothing";
+			}
+			else {
+				name = Lang.GetItemNameValue(item.type) + (item.modItem != null ? " [" + item.modItem.mod.Name + "]" : "");
+			}
+
+			information = new UIText(name, 0.8f);
+			information.Top.Pixels = 1;
+			information.Left.Pixels = 40;
+			Append(information);
+
+			percentText = new UIText(this.percent.ToString("0.00") + "%", 0.8f);
+			percentText.Left.Pixels = 40;
+			percentText.Top.Pixels = 18;
+			Append(percentText);
+		}
+
+		public override int CompareTo(object obj) {
+			UIFishingCatchesInfo other = obj as UIFishingCatchesInfo;
+			return -1 * percent.CompareTo(other.percent);
+		}
+
+		protected override void DrawSelf(SpriteBatch spriteBatch) {
+			base.DrawSelf(spriteBatch);
+
+			Rectangle hitbox = GetInnerDimensions().ToRectangle();
+			spriteBatch.Draw(Main.magicPixel, hitbox, Color.LightBlue * 0.6f);
+		}
+	}
+}

--- a/Tools/Fishing/UIFishingCatchesSlot.cs
+++ b/Tools/Fishing/UIFishingCatchesSlot.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Terraria;
+using Terraria.UI;
+using Terraria.DataStructures;
+
+namespace ModdersToolkit.Tools.Fishing
+{
+	// code based on SpawnUI
+	internal class UIFishingCatchesSlot : UIElement
+	{
+		public static Texture2D backgroundTexture = Main.inventoryBack9Texture;
+		private float scale = .6f;
+		public int itemType;
+		public Item item;
+
+		public UIFishingCatchesSlot(Item item) {
+			this.item = item;
+			this.itemType = item.type;
+			this.Width.Set(backgroundTexture.Width * scale, 0f);
+			this.Height.Set(backgroundTexture.Height * scale, 0f);
+		}
+
+		protected override void DrawSelf(SpriteBatch spriteBatch) {
+			//Main.instance.LoadItem(itemType);
+			Texture2D itemTexture = Main.itemTexture[itemType];
+
+			int width = itemTexture.Width;
+			int height = itemTexture.Height;
+
+			Rectangle itemDrawRectangle;
+			DrawAnimation drawAnim = Main.itemAnimations[itemType];
+			if (drawAnim != null) {
+				itemDrawRectangle = drawAnim.GetFrame(itemTexture);
+				height = itemDrawRectangle.Height;
+				width = itemDrawRectangle.Width;
+			}
+			else {
+				itemDrawRectangle = itemTexture.Bounds;
+			}
+
+			CalculatedStyle dimensions = base.GetInnerDimensions();
+			spriteBatch.Draw(backgroundTexture, dimensions.Position(), null, Color.White, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);
+
+			float drawScale = 2f;
+			float availableWidth = (float)backgroundTexture.Width * scale;
+			if (width * drawScale > availableWidth || height * drawScale > availableWidth) {
+				if (width > height) {
+					drawScale = availableWidth / width;
+				}
+				else {
+					drawScale = availableWidth / height;
+				}
+			}
+			Vector2 drawPosition = dimensions.Position();
+			drawPosition.X += backgroundTexture.Width * scale / 2f - (float)width * drawScale / 2f;
+			drawPosition.Y += backgroundTexture.Height * scale / 2f - (float)height * drawScale / 2f;
+
+			Color color = (item.color != new Color(byte.MinValue, byte.MinValue, byte.MinValue, byte.MinValue)) ? new Color(item.color.R, item.color.G, item.color.B, 255f) : new Color(1f, 1f, 1f);
+
+			spriteBatch.Draw(itemTexture, drawPosition, itemDrawRectangle, color, 0, Vector2.Zero, drawScale, SpriteEffects.None, 0);
+
+			if (IsMouseHovering) {
+				string name;
+				if (itemType <= 0) {
+					name = "Nothing";
+				}
+				else {
+					name = Lang.GetItemNameValue(item.type) + (item.modItem != null ? " [" + item.modItem.mod.Name + "]" : "");
+				}
+				Main.hoverItemName = name;
+			}
+		}
+
+		public override int CompareTo(object obj) {
+			UIFishingCatchesSlot other = obj as UIFishingCatchesSlot;
+			return /*-1 * */itemType.CompareTo(other.itemType);
+		}
+	}
+}


### PR DESCRIPTION
This PR adds another tool (next to the NPC spawn tool) to determine the drop table of fishing catches.
It works similarly to the NPC spawn tool UI wise.
Functionality wise it requires the player to be aligned vertically with a pool of liquid, then it seeks out the surface of a pool, and spawns a bobber above it. The player is then "spoofed" to be above the bobber, with all "wet" flags set to false, and AI is invoked repeatedly to collect data. 
Bobber AI is modified in that period to always generate a new item each cycle.